### PR TITLE
Add Django 1.9 support

### DIFF
--- a/daemonize.py
+++ b/daemonize.py
@@ -1,0 +1,62 @@
+import os
+import sys
+
+from . import six
+
+buffering = int(six.PY3)        # No unbuffered text I/O on Python 3 (#20815).
+
+if os.name == 'posix':
+    def become_daemon(our_home_dir='.', out_log='/dev/null',
+                      err_log='/dev/null', umask=0o022):
+        "Robustly turn into a UNIX daemon, running in our_home_dir."
+        # First fork
+        try:
+            if os.fork() > 0:
+                sys.exit(0)     # kill off parent
+        except OSError as e:
+            sys.stderr.write("fork #1 failed: (%d) %s\n" % (e.errno, e.strerror))
+            sys.exit(1)
+        os.setsid()
+        os.chdir(our_home_dir)
+        os.umask(umask)
+
+        # Second fork
+        try:
+            if os.fork() > 0:
+                os._exit(0)
+        except OSError as e:
+            sys.stderr.write("fork #2 failed: (%d) %s\n" % (e.errno, e.strerror))
+            os._exit(1)
+
+        si = open('/dev/null', 'r')
+        so = open(out_log, 'a+', buffering)
+        se = open(err_log, 'a+', buffering)
+        os.dup2(si.fileno(), sys.stdin.fileno())
+        os.dup2(so.fileno(), sys.stdout.fileno())
+        os.dup2(se.fileno(), sys.stderr.fileno())
+        # Set custom file descriptors so that they get proper buffering.
+        sys.stdout, sys.stderr = so, se
+else:
+    def become_daemon(our_home_dir='.', out_log=None, err_log=None, umask=0o022):
+        """
+        If we're not running under a POSIX system, just simulate the daemon
+        mode by doing redirections and directory changing.
+        """
+        os.chdir(our_home_dir)
+        os.umask(umask)
+        sys.stdin.close()
+        sys.stdout.close()
+        sys.stderr.close()
+        if err_log:
+            sys.stderr = open(err_log, 'a', buffering)
+        else:
+            sys.stderr = NullDevice()
+        if out_log:
+            sys.stdout = open(out_log, 'a', buffering)
+        else:
+            sys.stdout = NullDevice()
+
+    class NullDevice:
+        "A writeable object that writes to nowhere -- like /dev/null."
+        def write(self, s):
+            pass

--- a/daemonize.py
+++ b/daemonize.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from . import six
+from django.utils import six
 
 buffering = int(six.PY3)        # No unbuffered text I/O on Python 3 (#20815).
 

--- a/initd.py
+++ b/initd.py
@@ -53,7 +53,11 @@ class Initd(object):
                 logging.warn('Daemon already running.')
                 return
 
-        from django.utils.daemonize import become_daemon
+        try:
+            from django.utils.daemonize import become_daemon
+        except ImportError: # Django >= 1.9
+            from .daemonize import become_daemon
+
         become_daemon(self.workdir, self.stdout, self.stderr, self.umask)
 
         _initialize_logging(self.full_log_file)

--- a/initd.py
+++ b/initd.py
@@ -56,7 +56,7 @@ class Initd(object):
         try:
             from django.utils.daemonize import become_daemon
         except ImportError: # Django >= 1.9
-            from .daemonize import become_daemon
+            from daemonize import become_daemon
 
         become_daemon(self.workdir, self.stdout, self.stderr, self.umask)
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ doclines = __doc__.splitlines()
 
 setup(
     name = 'django-initd',
-    version = '0.0.2dev1',
+    version = '0.0.2dev2',
     py_modules = ['initd', 'daemon_command'],
     platforms = ['POSIX'],
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ doclines = __doc__.splitlines()
 
 setup(
     name = 'django-initd',
-    version = '0.0.2dev2',
+    version = '0.0.2dev3',
     py_modules = ['initd', 'daemon_command'],
     platforms = ['POSIX'],
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ doclines = __doc__.splitlines()
 
 setup(
     name = 'django-initd',
-    version = '0.0.2',
+    version = '0.0.2dev1',
     py_modules = ['initd', 'daemon_command'],
     platforms = ['POSIX'],
 

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ doclines = __doc__.splitlines()
 
 setup(
     name = 'django-initd',
-    version = '0.0.2dev3',
-    py_modules = ['initd', 'daemon_command'],
+    version = '0.0.2dev4',
+    py_modules = ['initd', 'daemon_command', 'daemonize'],
     platforms = ['POSIX'],
 
     install_requires = ['django>=1.0'],


### PR DESCRIPTION
daemonize is removed from Django 1.9 utils. Adding this to the package itself.
